### PR TITLE
Ensure coarse egress CIDR configuration of a security group is intended

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -39,14 +39,15 @@ resource "aws_security_group" "tfgoat-cluster" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
   egress {
     from_port   = 0
     to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    protocol    = "-1"            
+    # [Shisho]: remove `0.0.0.0/0` from the following line and add appropriate IP ranges
+    cidr_blocks = [ "0.0.0.0/0" ]
   }
 }
+
 
 resource "aws_security_group_rule" "tfgoat-cluster-ingress-workstation-https" {
   cidr_blocks       = ["0.0.0.0/0"]


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

Your security group allows egress traffic from all IPs, exposing resources in the VPC to unwanted attacks. Check this configuration is intended.

